### PR TITLE
Add setting global debconf settings (currently only for pbuilder)

### DIFF
--- a/debconf-selections.txt
+++ b/debconf-selections.txt
@@ -1,0 +1,1 @@
+pbuilder	pbuilder/mirrorsite	string	https://archive.ubuntu.com/ubuntu

--- a/installer-step3.sh
+++ b/installer-step3.sh
@@ -3,6 +3,9 @@
 # export config to current env
 . ./config.sh
 
+# set debconf selections "globally"
+debconf-set-selections < debconf-selections.txt
+
 # install packages
 . ./apt-install-cmds.sh
 


### PR DESCRIPTION
# Problem
Some packages (pbuilder) debconf selections prevent clean autoinstall (prompting values at installation).

# Solution
Provide `debconf-selections.txt` and set them early in installer step3 `debconf-set-selections < debconf-selections.txt`.

# Related
Fixes #2 