### PR TITLE
Working ISO Generation (Version 0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,9 @@ sudo apt-get install whois
 mkpasswd -m yescrypt
 ```
 
+> [!NOTE]
+> The password used in the default `autoinstall.yaml` config for both users `admin` and `user1` is: **password**.
+
 ## 5.2. Creating Bootable USB Installation Medium
 
 1. **Download Ubuntu 25.10 Desktop ISO** from the official Ubuntu website.

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ sudo apt-get install xorriso
 sudo xorriso \
   -as mkisofs \
   -V "Ubuntu 25.10 Hardened" \
-  --modification-date="$(shell date -u +"%Y%m%d%H%M%S00")" \
+  --modification-date="$(date -u +"%Y%m%d%H%M%S00")" \
   --grub2-mbr --interval:local_fs:0s-15s:zero_mbrpt,zero_gpt:'ubuntu-25.10-desktop-amd64.iso' \
   --protective-msdos-label \
   -partition_cyl_align off \

--- a/autoinstall/grub-autoinstall-entry.cfg
+++ b/autoinstall/grub-autoinstall-entry.cfg
@@ -1,0 +1,5 @@
+menuentry "Ubuntu Autoinstall" {
+	set gfxpayload=keep
+	linux	/casper/vmlinuz autoinstall ds=nocloud --- quiet splash
+	initrd	/casper/initrd
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@ apt-get install xorriso grub-pc-bin
 ## Run ISO Generation Script
 
 ```bash
-cd ../ && sudo ./scripts/mkiso.sh
+cd ./iso && sudo ../scripts/mkiso.sh
 ```
 
 > [!NOTE]

--- a/scripts/mkiso.sh
+++ b/scripts/mkiso.sh
@@ -6,22 +6,25 @@ cp -Ra /usr/lib/grub/i386-pc/eltorito.img /boot/grub/i386-pc/eltorito.img
 
 # extract Ubuntu ISO
 mkdir -p /tmp/ubuntu-iso /tmp/ubuntu-custom
-mount -o loop iso/ubuntu-25.10-desktop-amd64.iso /tmp/ubuntu-iso
+mount -o loop ubuntu-25.10-desktop-amd64.iso /tmp/ubuntu-iso
 cp -rT /tmp/ubuntu-iso /tmp/ubuntu-custom
 
 # add autoinstall configuration
 mkdir -p /tmp/ubuntu-custom/autoinstall
-cp autoinstall/autoinstall.yaml /tmp/ubuntu-custom/
+cp ../autoinstall/autoinstall.yaml /tmp/ubuntu-custom/
 
 # copy hardening scripts to ISO
 mkdir -p /tmp/ubuntu-custom/hardening
-cp *.sh *.conf *.toml *.yaml *.js /tmp/ubuntu-custom/hardening/
+cp ../*.sh ../*.conf ../*.toml ../*.yaml ../*.js /tmp/ubuntu-custom/hardening/
+
+# add grub autoinstall entry
+sed -i "7r ../autoinstall/grub-autoinstall-entry.cfg" /tmp/ubuntu-custom/boot/grub/grub.cfg
 
 # create custom (hybrid) ISO
 xorriso \
   -as mkisofs \
   -V "Ubuntu 25.10 Hardened" \
-  --modification-date="$(shell date -u +"%Y%m%d%H%M%S00")" \
+  --modification-date="$(date -u +"%Y%m%d%H%M%S00")" \
   --grub2-mbr --interval:local_fs:0s-15s:zero_mbrpt,zero_gpt:'ubuntu-25.10-desktop-amd64.iso' \
   --protective-msdos-label \
   -partition_cyl_align off \
@@ -40,5 +43,5 @@ xorriso \
   -e '--interval:appended_partition_2_start_2781704s_size_10256d:all::' \
   -no-emul-boot \
   -boot-load-size 10256 \
-  -o iso/ubuntu-25.10-hardened.iso \
+  -o ubuntu-25.10-hardened.iso \
   /tmp/ubuntu-custom/


### PR DESCRIPTION
# Problem
The ISO generation process described in `README.md` was not 100% correct. 

# Solution
I added a *working* script `/scripts/mkiso.sh` which also adds the grub autoinstall entry before the ISO is generated.

# Fixed
- Update documentation README.md(s)
- Add grub (autoinstall) template used by mkiso.sh
- Fix mkiso.sh (complete autoinstall process working including adding grub autoinstall entry)

# Fixes
Fixes #50, closes #49.

# Release
Version `0.3`.
